### PR TITLE
remove unnecessary code

### DIFF
--- a/src/ZkLean/range_analysis.lean
+++ b/src/ZkLean/range_analysis.lean
@@ -234,11 +234,9 @@ elab_rules : tactic
           -- let eqId := pr.mvarId!
           -- create a new factored hyphesis
           let gWithHyp ← g.assert `hMux prop pr
-          replaceMainGoal [pr.mvarId!, gWithHyp]
           updatedGoals := updatedGoals ++ [pr.mvarId!, gWithHyp]
           --logInfo m!"NEW GOALS: {pr.mvarId!}"
           --logInfo m!"NEW GOALS: {gWithHyp}"
-          setGoals updatedGoals
           applied := true
           handled := true
           progress := true


### PR DESCRIPTION
The code handling muxes does unnecessary goal manipulations:

1. It replaces the main goal, before replacing all goals.

2. It replaces all goals, then sets `handled` to `true`, which will cause all subsequent loop iterations to `continue`, until they reach the final `setGoals` after the loop over the goals.  Therefore, the first `setGoals` was redundant.

In general, I'd like to simplify this function a lot more, but starting small.